### PR TITLE
1 feature separate imap server into standalone service

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 ## 📌 Description
+
 <!-- Provide a clear, concise description of what this PR does. -->
 
 - Closes #<issue-number>
@@ -6,33 +7,38 @@
 ---
 
 ## 🔍 Changes Made
-<!-- List key changes in bullet points. -->
-- 
 
----
+<!-- List key changes in bullet points. -->
+
+- ***
 
 ## ✅ Checklist (Email System)
+
 - [ ] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
 - [ ] Authentication is tested.
 - [ ] Docker build & run validated.
 - [ ] Configuration loading verified for default and custom paths.
 - [ ] Persistent storage with Docker volume verified.
-- [ ] Error handling and logging verified.
+- [ ] Error handling and logging verifie
 - [ ] Documentation updated (README, config samples).
 
 ---
 
 ## 🧪 Testing Instructions
+
 <!-- Explain how reviewers can test your changes. -->
-1. 
+
+1.
 2.
 
 ---
 
 ## 📷 Screenshots / Logs (if applicable)
+
 <!-- Add screenshots of client tests, log snippets, etc. -->
 
 ---
 
 ## ⚠️ Notes for Reviewers
+
 <!-- Add special notes for reviewers (e.g., schema changes, ports affected, config updates). -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@
 - [ ] Docker build & run validated.
 - [ ] Configuration loading verified for default and custom paths.
 - [ ] Persistent storage with Docker volume verified.
-- [ ] Error handling and logging verifie
+- [ ] Error handling and logging verified
 - [ ] Documentation updated (README, config samples).
 
 ---

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,40 @@
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          IMAGE_NAME=ghcr.io/aravinda-hwk/silver-mda
+          VERSION=${GITHUB_REF_NAME}
+          docker build -t $IMAGE_NAME:latest -t $IMAGE_NAME:$VERSION .
+
+      - name: Push Docker image
+        run: |
+          IMAGE_NAME=ghcr.io/aravinda-hwk/silver-mda
+          VERSION=${GITHUB_REF_NAME}
+          docker push $IMAGE_NAME:latest
+          docker push $IMAGE_NAME:$VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore configuration and data directories
+config
+data
+
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,12 @@ This is a IMAP server implementation in Go for Silver Mail. It supports basic IM
 
 ```bash
 docker build -t silver-imap .
-docker run -it --rm -p 143:143 -p 993:993 silver-imap
+docker run -d --rm \
+  --name silver-imap \
+  -p 143:143 -p 993:993 \
+  -v $(pwd)/config:/etc/goImap \
+  -v $(pwd)/data:/app/data \
+  silver-imap
 ```
 
 3. The server will start and listen on ports 143 (IMAP) and 993 (IMAPS).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,66 @@
-# Silver Go IMAP Server
+# 📬 Silver Go IMAP Server
 
-This is a IMAP server implementation in Go for Silver Mail. It supports basic IMAP functionalities and is designed to be lightweight and efficient. 
+A lightweight and efficient IMAP server implementation in Go, designed for Silver Mail with support for core IMAP functionalities.
 
-## How to run the server
+---
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/Aravinda-HWK/Silver-IMAP.git
-   cd Silver-IMAP
-   ```
+## 🚀 Quick Start
 
-2. Build and run the Docker container:
+### Option 1: Pull from GitHub Container Registry (Recommended)
 
 ```bash
-docker build -t silver-imap .
+docker pull ghcr.io/aravinda-hwk/silver-mda:latest
 docker run -d --rm \
-  --name silver-imap \
+  --name silver-mda \
   -p 143:143 -p 993:993 \
   -v $(pwd)/config:/etc/goImap \
   -v $(pwd)/data:/app/data \
-  silver-imap
+  -v $(pwd)/certs:/certs \
+  ghcr.io/aravinda-hwk/silver-mda:latest
 ```
 
-3. The server will start and listen on ports 143 (IMAP) and 993 (IMAPS).
-4. You can connect to the server using any IMAP client.
+### Option 2: Build from Source
 
+1. Clone the repository:
+```bash
+git clone https://github.com/Aravinda-HWK/Silver-IMAP.git
+cd Silver-IMAP
+```
+
+2. Build and run:
+```bash
+docker build -t silver-mda .
+docker run -d --rm \
+  --name silver-mda \
+  -p 143:143 -p 993:993 \
+  -v $(pwd)/config:/etc/goImap \
+  -v $(pwd)/data:/app/data \
+  -v $(pwd)/certs:/certs \
+  silver-mda
+```
+
+The server will start and listen on:
+- **Port 143** - IMAP
+- **Port 993** - IMAPS
+
+Connect using any IMAP client to start managing your emails.
+
+---
+
+## 📂 Required Volume Mounts
+
+| Volume | Path | Description |
+|--------|------|-------------|
+| **Configuration** | `-v $(pwd)/config:/etc/goImap` | Configuration directory containing `goimap.yaml` |
+| **Data** | `-v $(pwd)/data:/app/data` | Data directory for SQLite database (`mail.db`) and mail storage |
+| **Certificates** | `-v $(pwd)/certs:/certs` | TLS/SSL certificates directory containing `fullchain.pem` and `privkey.pem` for IMAPS and STARTTLS |
+
+---
+
+## 🔐 Certificate Requirements
+
+Your `/certs` directory must contain:
+- `fullchain.pem` - Full certificate chain
+- `privkey.pem` - Private key
+
+These certificates are required for secure connections on port 993 and STARTTLS functionality.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module go-imap
 go 1.25
 
 require (
-	github.com/mattn/go-sqlite3 v1.14.32 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.32
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -6,17 +6,36 @@ import (
 )
 
 type Config struct {
-	Domain string `yaml:"domain"`
+	Domain        string `yaml:"domain"`
+	AuthServerURL string `yaml:"auth_server_url"`
 }
 
-func LoadConfig(path string) (*Config, error) {
-	data, err := ioutil.ReadFile(path)
+func LoadConfig() (*Config, error) {
+	var cfg Config
+
+	// Try multiple possible paths
+	configPaths := []string{
+		"/etc/goImap/goimap.yaml",
+		"./config/goimap.yaml",
+		"./goimap.yaml",
+		"config/goimap.yaml",
+	}
+
+	var data []byte
+	var err error
+	for _, path := range configPaths {
+		data, err = ioutil.ReadFile(path)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
-	var cfg Config
+
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+
 	return &cfg, nil
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -31,10 +31,11 @@ func (s *IMAPServer) handleLogin(conn net.Conn, tag string, parts []string, stat
 	cfg, err := conf.LoadConfig()
 	if err != nil {
 		log.Printf("LoadConfig error: %v", err)
+		s.sendResponse(conn, fmt.Sprintf("%s BAD LOGIN config error", tag))
+		return
 	}
 	log.Printf("Loaded config: %+v", cfg)
-
-	if err != nil || cfg.Domain == "" || cfg.AuthServerURL == "" {
+	if cfg.Domain == "" || cfg.AuthServerURL == "" {
 		s.sendResponse(conn, fmt.Sprintf("%s BAD LOGIN config error", tag))
 		return
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -175,15 +175,8 @@ func (s *IMAPServer) handleStartTLS(conn net.Conn, tag string) {
 	// Respond to client to begin TLS negotiation
 	s.sendResponse(conn, fmt.Sprintf("%s OK Begin TLS negotiation", tag))
 
-	// Load domain from config file
-	cfg, err := conf.LoadConfig()
-	if err != nil || cfg.Domain == "" {
-		fmt.Printf("Failed to load domain from config: %v\n", err)
-		return
-	}
-
-	certPath := fmt.Sprintf("/etc/letsencrypt/live/%s/fullchain.pem", cfg.Domain)
-	keyPath := fmt.Sprintf("/etc/letsencrypt/live/%s/privkey.pem", cfg.Domain)
+	certPath := "/certs/fullchain.pem"
+	keyPath := "/certs/privkey.pem"
 
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
@@ -202,16 +195,9 @@ func (s *IMAPServer) handleStartTLS(conn net.Conn, tag string) {
 }
 
 func (s *IMAPServer) HandleSSLConnection(conn net.Conn) {
-	// Load domain from config file
-	cfg, err := conf.LoadConfig()
-	if err != nil || cfg.Domain == "" {
-		log.Printf("Failed to load domain from config: %v", err)
-		conn.Close()
-		return
-	}
 
-	certPath := fmt.Sprintf("/etc/letsencrypt/live/%s/fullchain.pem", cfg.Domain)
-	keyPath := fmt.Sprintf("/etc/letsencrypt/live/%s/privkey.pem", cfg.Domain)
+	certPath := "/certs/fullchain.pem"
+	keyPath := "/certs/privkey.pem"
 
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -28,8 +28,13 @@ func (s *IMAPServer) handleLogin(conn net.Conn, tag string, parts []string, stat
 	password := strings.Trim(parts[3], "\"")
 
 	// Load domain from config file
-	cfg, err := conf.LoadConfig("/etc/goImap/silver.yaml")
-	if err != nil || cfg.Domain == "" {
+	cfg, err := conf.LoadConfig()
+	if err != nil {
+		log.Printf("LoadConfig error: %v", err)
+	}
+	log.Printf("Loaded config: %+v", cfg)
+
+	if err != nil || cfg.Domain == "" || cfg.AuthServerURL == "" {
 		s.sendResponse(conn, fmt.Sprintf("%s BAD LOGIN config error", tag))
 		return
 	}
@@ -40,7 +45,7 @@ func (s *IMAPServer) handleLogin(conn net.Conn, tag string, parts []string, stat
 	requestBody := fmt.Sprintf(`{"email":"%s","password":"%s"}`, email, password)
 
 	// Create HTTP request
-	req, err := http.NewRequest("POST", "https://thunder-server:8090/users/authenticate", strings.NewReader(requestBody))
+	req, err := http.NewRequest("POST", cfg.AuthServerURL, strings.NewReader(requestBody))
 	if err != nil {
 		s.sendResponse(conn, fmt.Sprintf("%s BAD LOGIN internal error", tag))
 		return
@@ -171,7 +176,7 @@ func (s *IMAPServer) handleStartTLS(conn net.Conn, tag string) {
 	s.sendResponse(conn, fmt.Sprintf("%s OK Begin TLS negotiation", tag))
 
 	// Load domain from config file
-	cfg, err := conf.LoadConfig("/etc/goImap/silver.yaml")
+	cfg, err := conf.LoadConfig()
 	if err != nil || cfg.Domain == "" {
 		fmt.Printf("Failed to load domain from config: %v\n", err)
 		return
@@ -198,7 +203,7 @@ func (s *IMAPServer) handleStartTLS(conn net.Conn, tag string) {
 
 func (s *IMAPServer) HandleSSLConnection(conn net.Conn) {
 	// Load domain from config file
-	cfg, err := conf.LoadConfig("/etc/goImap/silver.yaml")
+	cfg, err := conf.LoadConfig()
 	if err != nil || cfg.Domain == "" {
 		log.Printf("Failed to load domain from config: %v", err)
 		conn.Close()


### PR DESCRIPTION
## 📌 Description
The main idea of this PR is to separate the IMAP service into a standalone service and the IDP, and the database for storing the mails can be configurable using this.

- Closes #1 

---

## 🔍 Changes Made
<!-- List key changes in bullet points. -->

- File paths are taken from the .yaml file.
- Database can be mounted using a volume.
- Certificates can be mounted using a volume.

---

## ✅ Checklist (Email System)
- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified.
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions
N/A

---

## 📷 Screenshots / Logs (if applicable)
N/A

---

## ⚠️ Notes for Reviewers
N/A