### PR TITLE
feat: implement AUTHENTICATE command handling with base64 support and…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Test APPEND command
         run: go test -tags=test -v ./test/server -run "TestAppendCommand"
+
+      - name: Test AUTHENTICATE command
+        run: go test -tags=test -v ./test/server -run "TestAuthenticate"

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 # Makefile for Go IMAP Server Testing
 #
 # Quick Reference:
-#   make test            - Run all tests
-#   make test-noop       - Run NOOP command tests
-#   make test-capability - Run CAPABILITY command tests
-#   make test-logout     - Run LOGOUT command tests
-#   make test-append     - Run APPEND command tests
-#   make test-commands   - Run all command tests
-#   make help            - Show all available targets
+#   make test              - Run all tests
+#   make test-noop         - Run NOOP command tests
+#   make test-capability   - Run CAPABILITY command tests
+#   make test-logout       - Run LOGOUT command tests
+#   make test-append       - Run APPEND command tests
+#   make test-authenticate - Run AUTHENTICATE command tests
+#   make test-commands     - Run all command tests
+#   make help              - Show all available targets
 
-.PHONY: test test-capability test-noop test-commands test-verbose test-coverage test-race clean
+.PHONY: test test-capability test-noop test-authenticate test-commands test-verbose test-coverage test-race clean
 
 # Run all tests
 test:
@@ -31,7 +32,15 @@ test-logout:
 test-append:
 	go test -tags=test -v ./test/server -run "TestAppendCommand"
 
-# Run all command tests (CAPABILITY + NOOP + LOGOUT + APPEND)
+# Run only AUTHENTICATE-related tests
+test-authenticate:
+	go test -tags=test -v ./test/server -run "TestAuthenticate"
+
+# Run AUTHENTICATE benchmarks
+bench-authenticate:
+	go test -tags=test -bench=BenchmarkAuthenticate -benchmem ./test/server
+
+# Run all command tests (CAPABILITY + NOOP + LOGOUT + APPEND + AUTHENTICATE)
 test-commands:
 	@echo "Running CAPABILITY tests..."
 	@go test -tags=test -v ./test/server -run "TestCapabilityCommand"
@@ -41,6 +50,8 @@ test-commands:
 	@go test -tags=test -v ./test/server -run "TestLogoutCommand"
 	@echo "\nRunning APPEND tests..."
 	@go test -tags=test -v ./test/server -run "TestAppendCommand"
+	@echo "\nRunning AUTHENTICATE tests..."
+	@go test -tags=test -v ./test/server -run "TestAuthenticate"
 
 # Run tests with verbose output
 test-verbose:
@@ -102,26 +113,28 @@ help:
 	@echo "Available targets:"
 	@echo ""
 	@echo "Testing:"
-	@echo "  test                 - Run all tests"
-	@echo "  test-capability      - Run CAPABILITY command tests only"
-	@echo "  test-noop            - Run NOOP command tests only"
-	@echo "  test-logout          - Run LOGOUT command tests only"
-	@echo "  test-append          - Run APPEND command tests only"
-	@echo "  test-commands        - Run all command tests (CAPABILITY + NOOP + LOGOUT + APPEND)"
-	@echo "  test-verbose         - Run tests with verbose output"
-	@echo "  test-coverage        - Run tests with coverage report"
-	@echo "  test-race            - Run tests with race detection"
-	@echo "  bench                - Run benchmarks"
-	@echo "  test-single TEST=... - Run a specific test"
+	@echo "  test                   - Run all tests"
+	@echo "  test-capability        - Run CAPABILITY command tests only"
+	@echo "  test-noop              - Run NOOP command tests only"
+	@echo "  test-logout            - Run LOGOUT command tests only"
+	@echo "  test-append            - Run APPEND command tests only"
+	@echo "  test-authenticate      - Run AUTHENTICATE command tests only"
+	@echo "  test-commands          - Run all command tests (CAPABILITY + NOOP + LOGOUT + APPEND + AUTHENTICATE)"
+	@echo "  test-verbose           - Run tests with verbose output"
+	@echo "  test-coverage          - Run tests with coverage report"
+	@echo "  test-race              - Run tests with race detection"
+	@echo "  bench                  - Run all benchmarks"
+	@echo "  bench-authenticate     - Run AUTHENTICATE benchmarks"
+	@echo "  test-single TEST=...   - Run a specific test"
 	@echo ""
 	@echo "Development:"
-	@echo "  deps                 - Install dependencies"
-	@echo "  fmt                  - Format code"
-	@echo "  lint                 - Lint code"
-	@echo "  clean                - Clean test artifacts"
+	@echo "  deps                   - Install dependencies"
+	@echo "  fmt                    - Format code"
+	@echo "  lint                   - Lint code"
+	@echo "  clean                  - Clean test artifacts"
 	@echo ""
 	@echo "CI/CD:"
-	@echo "  check                - Run all quality checks"
-	@echo "  ci                   - Run CI pipeline"
+	@echo "  check                  - Run all quality checks"
+	@echo "  ci                     - Run CI pipeline"
 	@echo ""
-	@echo "  help                 - Show this help"
+	@echo "  help                   - Show this help"

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -75,3 +75,8 @@ func (t *TestInterface) HandleAuthenticate(conn net.Conn, tag string, parts []st
 func (t *TestInterface) SendResponse(conn net.Conn, response string) {
 	t.server.sendResponse(conn, response)
 }
+
+// HandleClientExported exposes handleClient for testing
+func HandleClientExported(server *TestInterface, conn net.Conn) {
+	handleClient(server.server, conn, &models.ClientState{})
+}

--- a/test/README.md
+++ b/test/README.md
@@ -26,7 +26,11 @@ Contains reusable test utilities:
 ### server/
 Contains all server-related tests:
 - **capability_test.go**: RFC 3501 compliance tests, edge cases, performance tests
-- **handlers_test.go**: Integration tests for IMAP command handlers
+- **authenticate_test.go**: AUTHENTICATE PLAIN command tests with base64 encoding/decoding
+- **noop_test.go**: NOOP command tests for mailbox state management
+- **logout_test.go**: LOGOUT command tests for connection cleanup
+- **append_test.go**: APPEND command tests for adding messages to mailboxes
+- **handlers_test.go**: Integration tests for various IMAP command handlers
 
 ## Running Tests
 
@@ -38,6 +42,9 @@ make test
 
 # Run only capability tests
 make test-capability
+
+# Run only authenticate tests
+make test-authenticate
 
 # Run tests with verbose output
 make test-verbose

--- a/test/server/append_test.go
+++ b/test/server/append_test.go
@@ -82,7 +82,7 @@ func TestAppendCommand_WithFlags(t *testing.T) {
 
 // TestAppendCommand_NotAuthenticated tests APPEND without authentication
 func TestAppendCommand_NotAuthenticated(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	state := &models.ClientState{
@@ -108,7 +108,7 @@ func TestAppendCommand_NotAuthenticated(t *testing.T) {
 
 // TestAppendCommand_InvalidFolder tests APPEND to non-existent folder
 func TestAppendCommand_InvalidFolder(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	state := &models.ClientState{
@@ -189,7 +189,7 @@ func TestAppendCommand_ToDrafts(t *testing.T) {
 
 // TestAppendCommand_MissingSize tests APPEND without literal size
 func TestAppendCommand_MissingSize(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	state := &models.ClientState{

--- a/test/server/authenticate_test.go
+++ b/test/server/authenticate_test.go
@@ -1,0 +1,238 @@
+package server
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"go-imap/internal/models"
+	"go-imap/test/helpers"
+)
+
+// TestAuthenticatePlainBasicFlow tests the basic AUTHENTICATE PLAIN command flow
+func TestAuthenticatePlainBasicFlow(t *testing.T) {
+	s, cleanup := helpers.SetupTestServer(t)
+	defer cleanup()
+
+	conn := helpers.NewMockTLSConn() // Use TLS connection
+	state := &models.ClientState{Authenticated: false}
+
+	// Send AUTHENTICATE PLAIN command
+	s.HandleAuthenticate(conn, "A001", []string{"A001", "AUTHENTICATE", "PLAIN"}, state)
+
+	response := conn.GetWrittenData()
+	
+	// Should get continuation response
+	if !strings.Contains(response, "+ ") {
+		t.Errorf("Expected continuation response '+', got: %s", response)
+	}
+}
+
+// TestAuthenticatePlainBase64Decoding tests successful base64 decoding
+func TestAuthenticatePlainBase64Decoding(t *testing.T) {
+	// Test base64 encoding/decoding of credentials
+	authString := "\x00testuser\x00testpass"
+	authEncoded := base64.StdEncoding.EncodeToString([]byte(authString))
+	
+	decoded, err := base64.StdEncoding.DecodeString(authEncoded)
+	if err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+	
+	parts := strings.Split(string(decoded), "\x00")
+	if len(parts) != 3 {
+		t.Errorf("Expected 3 parts, got %d", len(parts))
+	}
+	
+	if parts[1] != "testuser" {
+		t.Errorf("Expected username 'testuser', got '%s'", parts[1])
+	}
+	
+	if parts[2] != "testpass" {
+		t.Errorf("Expected password 'testpass', got '%s'", parts[2])
+	}
+}
+
+// TestAuthenticatePlainWithAuthzid tests AUTHENTICATE PLAIN with authorization identity
+func TestAuthenticatePlainWithAuthzid(t *testing.T) {
+	// Test format with authzid: authzid\x00authcid\x00password
+	authString := "testuser\x00testuser\x00testpass"
+	authEncoded := base64.StdEncoding.EncodeToString([]byte(authString))
+	
+	decoded, err := base64.StdEncoding.DecodeString(authEncoded)
+	if err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+	
+	parts := strings.Split(string(decoded), "\x00")
+	if len(parts) != 3 {
+		t.Errorf("Expected 3 parts, got %d", len(parts))
+	}
+	
+	// authzid, authcid, password
+	if parts[0] != "testuser" {
+		t.Errorf("Expected authzid 'testuser', got '%s'", parts[0])
+	}
+	if parts[1] != "testuser" {
+		t.Errorf("Expected authcid 'testuser', got '%s'", parts[1])
+	}
+	if parts[2] != "testpass" {
+		t.Errorf("Expected password 'testpass', got '%s'", parts[2])
+	}
+}
+
+// TestAuthenticateWithoutTLS tests that AUTHENTICATE is rejected without TLS
+func TestAuthenticateWithoutTLS(t *testing.T) {
+	s, cleanup := helpers.SetupTestServer(t)
+	defer cleanup()
+
+	conn := helpers.NewMockConn() // Plain connection, not TLS
+	state := &models.ClientState{Authenticated: false}
+
+	// Send AUTHENTICATE PLAIN command
+	s.HandleAuthenticate(conn, "A001", []string{"A001", "AUTHENTICATE", "PLAIN"}, state)
+
+	response := conn.GetWrittenData()
+	
+	// Should get NO response (plaintext auth disallowed)
+	if !strings.Contains(response, "A001 NO") {
+		t.Errorf("Expected NO response without TLS, got: %s", response)
+	}
+	if !strings.Contains(strings.ToLower(response), "tls") {
+		t.Errorf("Expected TLS-related message, got: %s", response)
+	}
+}
+
+// TestAuthenticateUnsupportedMechanism tests unsupported authentication mechanism
+func TestAuthenticateUnsupportedMechanism(t *testing.T) {
+	s, cleanup := helpers.SetupTestServer(t)
+	defer cleanup()
+
+	conn := helpers.NewMockTLSConn()
+	state := &models.ClientState{Authenticated: false}
+
+	// Send AUTHENTICATE with unsupported mechanism
+	s.HandleAuthenticate(conn, "A001", []string{"A001", "AUTHENTICATE", "GSSAPI"}, state)
+
+	response := conn.GetWrittenData()
+	
+	// Should get NO response
+	if !strings.Contains(response, "A001 NO") {
+		t.Errorf("Expected NO response for unsupported mechanism, got: %s", response)
+	}
+	if !strings.Contains(strings.ToLower(response), "unsupported") {
+		t.Errorf("Expected 'unsupported' in response, got: %s", response)
+	}
+}
+
+// TestAuthenticateMissingMechanism tests AUTHENTICATE without mechanism
+func TestAuthenticateMissingMechanism(t *testing.T) {
+	s, cleanup := helpers.SetupTestServer(t)
+	defer cleanup()
+
+	conn := helpers.NewMockTLSConn()
+	state := &models.ClientState{Authenticated: false}
+
+	// Send AUTHENTICATE without mechanism
+	s.HandleAuthenticate(conn, "A001", []string{"A001", "AUTHENTICATE"}, state)
+
+	response := conn.GetWrittenData()
+	
+	// Should get BAD response
+	if !strings.Contains(response, "A001 BAD") {
+		t.Errorf("Expected BAD response for missing mechanism, got: %s", response)
+	}
+}
+
+// TestAuthenticatePlainCaseInsensitive tests that mechanism name is case-insensitive
+func TestAuthenticatePlainCaseInsensitive(t *testing.T) {
+	s, cleanup := helpers.SetupTestServer(t)
+	defer cleanup()
+
+	mechanisms := []string{"PLAIN", "Plain", "plain", "pLaIn"}
+
+	for _, mechanism := range mechanisms {
+		t.Run("Mechanism_"+mechanism, func(t *testing.T) {
+			conn := helpers.NewMockTLSConn()
+			state := &models.ClientState{Authenticated: false}
+
+			// Send AUTHENTICATE with various cases
+			s.HandleAuthenticate(conn, "A001", []string{"A001", "AUTHENTICATE", mechanism}, state)
+
+			response := conn.GetWrittenData()
+			
+			// Should get continuation response for all case variations
+			if !strings.Contains(response, "+ ") {
+				t.Errorf("Expected continuation response for %s, got: %s", mechanism, response)
+			}
+		})
+	}
+}
+
+// TestAuthenticateBase64InvalidFormat tests handling of invalid base64 format
+func TestAuthenticateBase64InvalidFormat(t *testing.T) {
+	// Test that invalid base64 is handled gracefully
+	invalidBase64 := "!!!invalid-base64!!!"
+	
+	_, err := base64.StdEncoding.DecodeString(invalidBase64)
+	if err == nil {
+		t.Error("Expected error for invalid base64, got nil")
+	}
+}
+
+// TestAuthenticatePlainEmptyCredentials tests rejection of empty credentials
+func TestAuthenticatePlainEmptyCredentials(t *testing.T) {
+	// Test empty credentials format
+	authString := "\x00\x00"
+	authEncoded := base64.StdEncoding.EncodeToString([]byte(authString))
+	
+	decoded, err := base64.StdEncoding.DecodeString(authEncoded)
+	if err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+	
+	parts := strings.Split(string(decoded), "\x00")
+	
+	// Check that we can detect empty username/password
+	hasEmpty := false
+	for i, part := range parts {
+		if part == "" && i > 0 { // Skip authzid (index 0)
+			hasEmpty = true
+		}
+	}
+	
+	if !hasEmpty {
+		t.Error("Expected to detect empty credentials")
+	}
+}
+
+// TestAuthenticatePlainMalformedData tests handling of malformed data (no NUL separators)
+func TestAuthenticatePlainMalformedData(t *testing.T) {
+	// Test data without NUL separators
+	authString := "usernamepassword"
+	authEncoded := base64.StdEncoding.EncodeToString([]byte(authString))
+	
+	decoded, err := base64.StdEncoding.DecodeString(authEncoded)
+	if err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+	
+	parts := strings.Split(string(decoded), "\x00")
+	
+	// Should have only 1 part (no NUL separators)
+	if len(parts) != 1 {
+		t.Errorf("Expected 1 part for malformed data, got %d", len(parts))
+	}
+}
+
+// BenchmarkAuthenticatePlainBase64 benchmarks base64 encoding/decoding
+func BenchmarkAuthenticatePlainBase64(b *testing.B) {
+	authString := "\x00testuser\x00testpass"
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		authEncoded := base64.StdEncoding.EncodeToString([]byte(authString))
+		decoded, _ := base64.StdEncoding.DecodeString(authEncoded)
+		_ = strings.Split(string(decoded), "\x00")
+	}
+}

--- a/test/server/capability_test.go
+++ b/test/server/capability_test.go
@@ -73,7 +73,7 @@ func TestCapabilityCommand_RFCCompliance(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := helpers.SetupTestServer(t)
+			server := helpers.SetupTestServerSimple(t)
 			var conn helpers.MockConnInterface
 			
 			if tt.connType == "tls" {
@@ -127,7 +127,7 @@ func TestCapabilityCommand_TagHandling(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Tag_%s", tc.tag), func(t *testing.T) {
-			server := helpers.SetupTestServer(t)
+			server := helpers.SetupTestServerSimple(t)
 			conn := helpers.NewMockConn()
 			state := &models.ClientState{Authenticated: false}
 
@@ -153,7 +153,7 @@ func TestCapabilityCommand_TagHandling(t *testing.T) {
 
 // TestCapabilityCommand_CapabilityFormatting tests capability string formatting
 func TestCapabilityCommand_CapabilityFormatting(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{Authenticated: false}
 
@@ -210,7 +210,7 @@ func TestCapabilityCommand_CapabilityFormatting(t *testing.T) {
 // TestCapabilityCommand_EdgeCases tests edge cases and error conditions
 func TestCapabilityCommand_EdgeCases(t *testing.T) {
 	t.Run("EmptyTag", func(t *testing.T) {
-		server := helpers.SetupTestServer(t)
+		server := helpers.SetupTestServerSimple(t)
 		conn := helpers.NewMockConn()
 		state := &models.ClientState{Authenticated: false}
 
@@ -227,7 +227,7 @@ func TestCapabilityCommand_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("NilState", func(t *testing.T) {
-		server := helpers.SetupTestServer(t)
+		server := helpers.SetupTestServerSimple(t)
 		conn := helpers.NewMockConn()
 
 		// This should not panic
@@ -243,7 +243,7 @@ func TestCapabilityCommand_EdgeCases(t *testing.T) {
 
 // TestCapabilityCommand_ResponseTiming tests response timing and ordering
 func TestCapabilityCommand_ResponseTiming(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{Authenticated: false}
 
@@ -275,7 +275,7 @@ func TestCapabilityCommand_ResponseTiming(t *testing.T) {
 
 // TestCapabilityCommand_MemoryUsage tests for memory leaks or excessive allocation
 func TestCapabilityCommand_MemoryUsage(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	
 	// Run many capability commands to check for memory issues
 	for i := 0; i < 1000; i++ {
@@ -294,7 +294,7 @@ func TestCapabilityCommand_MemoryUsage(t *testing.T) {
 
 // TestCapabilityCommand_StateIsolation tests that different states don't interfere
 func TestCapabilityCommand_StateIsolation(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 
 	states := []*models.ClientState{
 		{Authenticated: false, Username: ""},

--- a/test/server/handlers_test.go
+++ b/test/server/handlers_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestCapabilityCommand_NonTLSConnection tests CAPABILITY command over non-TLS connection
 func TestCapabilityCommand_NonTLSConnection(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
@@ -75,7 +75,7 @@ func TestCapabilityCommand_NonTLSConnection(t *testing.T) {
 
 // TestCapabilityCommand_TLSConnection tests CAPABILITY command over TLS connection
 func TestCapabilityCommand_TLSConnection(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockTLSConn()
 	state := &models.ClientState{
 		Authenticated: false,
@@ -127,7 +127,7 @@ func TestCapabilityCommand_TLSConnection(t *testing.T) {
 
 // TestCapabilityCommand_ResponseFormat tests the exact format of CAPABILITY response
 func TestCapabilityCommand_ResponseFormat(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
@@ -180,7 +180,7 @@ func TestCapabilityCommand_ResponseFormat(t *testing.T) {
 
 // TestCapabilityCommand_MultipleInvocations tests calling CAPABILITY multiple times
 func TestCapabilityCommand_MultipleInvocations(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
@@ -223,7 +223,7 @@ func TestCapabilityCommand_MultipleInvocations(t *testing.T) {
 // TestCapabilityCommand_AuthenticationStateDoesNotAffectCapabilities tests that 
 // authentication state doesn't change capabilities (connection type does)
 func TestCapabilityCommand_AuthenticationStateDoesNotAffectCapabilities(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 
 	// Test with unauthenticated state
 	conn1 := helpers.NewMockConn()
@@ -259,7 +259,7 @@ func TestCapabilityCommand_AuthenticationStateDoesNotAffectCapabilities(t *testi
 
 // BenchmarkCapabilityCommand benchmarks the CAPABILITY command performance
 func BenchmarkCapabilityCommand(b *testing.B) {
-	server := helpers.SetupTestServer(&testing.T{})
+	server := helpers.SetupTestServerSimple(&testing.T{})
 	state := &models.ClientState{
 		Authenticated: false,
 	}
@@ -273,7 +273,7 @@ func BenchmarkCapabilityCommand(b *testing.B) {
 
 // TestCapabilityCommand_ConcurrentAccess tests concurrent CAPABILITY requests
 func TestCapabilityCommand_ConcurrentAccess(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	
 	// Number of concurrent requests
 	const numRequests = 10

--- a/test/server/logout_test.go
+++ b/test/server/logout_test.go
@@ -14,7 +14,7 @@ import (
 // TestLogoutCommand_Unauthenticated tests LOGOUT before authentication
 // RFC 3501: LOGOUT can be used in any state
 func TestLogoutCommand_Unauthenticated(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	server.HandleLogout(conn, "L001")
@@ -41,7 +41,7 @@ func TestLogoutCommand_Unauthenticated(t *testing.T) {
 
 // TestLogoutCommand_Authenticated tests LOGOUT after successful authentication
 func TestLogoutCommand_Authenticated(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	server.HandleLogout(conn, "A023")
@@ -73,7 +73,7 @@ func TestLogoutCommand_Authenticated(t *testing.T) {
 
 // TestLogoutCommand_WithSelectedFolder tests LOGOUT with a folder selected
 func TestLogoutCommand_WithSelectedFolder(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	// Simulate state with selected folder
@@ -106,7 +106,7 @@ func TestLogoutCommand_WithSelectedFolder(t *testing.T) {
 // TestLogoutCommand_ResponseOrder tests that BYE is sent before OK
 // This is a MUST requirement from RFC 3501
 func TestLogoutCommand_ResponseOrder(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	server.HandleLogout(conn, "L004")
@@ -147,7 +147,7 @@ func TestLogoutCommand_ResponseOrder(t *testing.T) {
 // TestLogoutCommand_MultipleSequentialLogouts tests multiple LOGOUT commands
 // (though in practice connection closes after first)
 func TestLogoutCommand_MultipleSequentialLogouts(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 
 	testCases := []struct {
 		tag          string
@@ -183,7 +183,7 @@ func TestLogoutCommand_MultipleSequentialLogouts(t *testing.T) {
 // TestLogoutCommand_AlwaysSucceeds tests that LOGOUT always returns OK
 // LOGOUT should never fail with BAD or NO response
 func TestLogoutCommand_AlwaysSucceeds(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	server.HandleLogout(conn, "L005")
@@ -207,7 +207,7 @@ func TestLogoutCommand_AlwaysSucceeds(t *testing.T) {
 
 // TestLogoutCommand_NoArguments tests that LOGOUT doesn't require arguments
 func TestLogoutCommand_NoArguments(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	// LOGOUT takes no arguments, just tag
@@ -246,7 +246,7 @@ func TestLogoutCommand_TagFormat(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			server := helpers.SetupTestServer(t)
+			server := helpers.SetupTestServerSimple(t)
 			conn := helpers.NewMockConn()
 
 			server.HandleLogout(conn, tc.tag)
@@ -269,7 +269,7 @@ func TestLogoutCommand_TagFormat(t *testing.T) {
 
 // TestLogoutCommand_MessageContent tests the content of BYE message
 func TestLogoutCommand_MessageContent(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 
 	server.HandleLogout(conn, "L007")

--- a/test/server/noop_test.go
+++ b/test/server/noop_test.go
@@ -13,7 +13,7 @@ import (
 
 // TestNoopCommand_Unauthenticated tests NOOP before authentication
 func TestNoopCommand_Unauthenticated(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: false,
@@ -38,7 +38,7 @@ func TestNoopCommand_Unauthenticated(t *testing.T) {
 
 // TestNoopCommand_AuthenticatedNoFolder tests NOOP when authenticated but no folder selected
 func TestNoopCommand_AuthenticatedNoFolder(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{
 		Authenticated:  true,
@@ -65,7 +65,7 @@ func TestNoopCommand_AuthenticatedNoFolder(t *testing.T) {
 
 // TestNoopCommand_WithSelectedFolder tests NOOP with selected folder (no changes)
 func TestNoopCommand_WithSelectedFolder(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{
 		Authenticated:    true,
@@ -132,7 +132,7 @@ func TestNoopCommand_AlwaysSucceeds(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			server := helpers.SetupTestServer(t)
+			server := helpers.SetupTestServerSimple(t)
 			conn := helpers.NewMockConn()
 
 			server.HandleNoop(conn, tc.tag, tc.state)
@@ -155,7 +155,7 @@ func TestNoopCommand_AlwaysSucceeds(t *testing.T) {
 
 // TestNoopCommand_ResponseFormat tests the format of NOOP responses
 func TestNoopCommand_ResponseFormat(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: true,
@@ -182,7 +182,7 @@ func TestNoopCommand_ResponseFormat(t *testing.T) {
 
 // TestNoopCommand_MultipleInvocations tests calling NOOP multiple times
 func TestNoopCommand_MultipleInvocations(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	state := &models.ClientState{
 		Authenticated: true,
@@ -210,7 +210,7 @@ func TestNoopCommand_MultipleInvocations(t *testing.T) {
 
 // TestNoopCommand_StateTracking tests that NOOP updates state correctly
 func TestNoopCommand_StateTracking(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	conn := helpers.NewMockConn()
 	
 	// Start with initial state
@@ -253,7 +253,7 @@ func TestNoopCommand_TagHandling(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("Tag_"+tc.tag, func(t *testing.T) {
-			server := helpers.SetupTestServer(t)
+			server := helpers.SetupTestServerSimple(t)
 			conn := helpers.NewMockConn()
 			state := &models.ClientState{Authenticated: false}
 
@@ -271,7 +271,7 @@ func TestNoopCommand_TagHandling(t *testing.T) {
 
 // TestNoopCommand_ConcurrentAccess tests concurrent NOOP requests
 func TestNoopCommand_ConcurrentAccess(t *testing.T) {
-	server := helpers.SetupTestServer(t)
+	server := helpers.SetupTestServerSimple(t)
 	
 	const numRequests = 20
 	done := make(chan bool, numRequests)
@@ -303,7 +303,7 @@ func TestNoopCommand_ConcurrentAccess(t *testing.T) {
 // TestNoopCommand_RFC3501Compliance tests RFC 3501 compliance
 func TestNoopCommand_RFC3501Compliance(t *testing.T) {
 	t.Run("Always succeeds", func(t *testing.T) {
-		server := helpers.SetupTestServer(t)
+		server := helpers.SetupTestServerSimple(t)
 		conn := helpers.NewMockConn()
 		state := &models.ClientState{}
 
@@ -316,7 +316,7 @@ func TestNoopCommand_RFC3501Compliance(t *testing.T) {
 	})
 
 	t.Run("Can be used for polling", func(t *testing.T) {
-		server := helpers.SetupTestServer(t)
+		server := helpers.SetupTestServerSimple(t)
 		conn := helpers.NewMockConn()
 		state := &models.ClientState{
 			Authenticated:    true,
@@ -341,7 +341,7 @@ func TestNoopCommand_RFC3501Compliance(t *testing.T) {
 	t.Run("Resets inactivity timer", func(t *testing.T) {
 		// This is implicit - by processing the command, the server
 		// resets any inactivity timer. We just verify NOOP works.
-		server := helpers.SetupTestServer(t)
+		server := helpers.SetupTestServerSimple(t)
 		conn := helpers.NewMockConn()
 		state := &models.ClientState{Authenticated: true}
 


### PR DESCRIPTION
## 📌 Description

This PR is created to resolve the issue in Apple Mail. Mails are not visible in Apple Mail but they can be seen in Thunderbird Mail User Agent.

- Closes #13 

---

## 🔍 Changes Made

- Added AUTHENTICATE command handling in handlers.go with support for PLAIN mechanism.
- Implemented base64 encoding/decoding for credentials.
- Added tests for the AUTHENTICATE command in authenticate_test.go covering various scenarios including TLS checks, case insensitivity, and malformed data.
- Updated Makefile and README.md to include new test commands and descriptions.
- Enhanced CI workflow to include tests for the AUTHENTICATE command.

- ***

## ✅ Checklist (Email System)

- [x] Core IMAP commands tested (`LOGIN`, `CAPABILITY`, `LIST`, `SELECT`, `FETCH`, `LOGOUT`).
- [x] Authentication is tested.
- [x] Docker build & run validated.
- [x] Configuration loading verified for default and custom paths.
- [x] Persistent storage with Docker volume verified.
- [x] Error handling and logging verified
- [x] Documentation updated (README, config samples).

---

## 🧪 Testing Instructions

N/A

---

## 📷 Screenshots / Logs (if applicable)

N/A

---

## ⚠️ Notes for Reviewers

N/A
